### PR TITLE
Enable Bearer Schema in HTTP Authorization header

### DIFF
--- a/lib/Dancer2/Plugin/JWT.pm
+++ b/lib/Dancer2/Plugin/JWT.pm
@@ -175,6 +175,14 @@ on_plugin_import {
                 my $app = shift;
                 my $encoded = $app->request->headers->authorization;
 
+                if( defined $encoded ) {
+                    # Remove "Bearer " (sic) from the beginning of the Authorization header if present.
+                    # "Bearer" signifies the schema and should be present
+                    # but due to backwards compatibility we support also without it.
+                    # https://jwt.io/introduction/ (How do JSON Web Tokens work?)
+                    $encoded =~ m/^ (?: Bearer [[:space:]]{1} | ) (?<token> [^[:space:]]{0,} ) $/msx;
+                    $encoded = $+{token};
+                }
 
                 if ($app->request->cookies->{_jwt}) {
                     $encoded = $app->request->cookies->{_jwt}->value ;

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -59,6 +59,21 @@ $mech->add_header("Authorization" => $authorization);
 $mech->get_ok("/defined/jwt");
 $mech->content_is("DEFINED", "We got something");
 
+# Auth header with Bearer schema
+$mech->add_header("Authorization" => 'Bearer ' . $authorization);
+$mech->get_ok("/defined/jwt");
+$mech->content_is("DEFINED", "We got something");
+
+# Wrong number of spaces in Auth header
+$mech->add_header("Authorization" => 'Bearer  ' . $authorization);
+$mech->get_ok("/redirect/jwt");
+$mech->content_is("OK", "we redirected");
+
+# Auth header with a wrong schema
+$mech->add_header("Authorization" => 'Basic ' . $authorization);
+$mech->get_ok("/redirect/jwt");
+$mech->content_is("OK", "we redirected");
+
 $mech->delete_header("Authorization");
 $mech->get_ok("/redirect/jwt");
 $mech->content_is("OK", "we redirected");


### PR DESCRIPTION
Allow client to specify schema in the HTTP Authorization header,
e.g.
Authorization: Bearer eyJhbGci...<snip>...yu5CSpyHI

https://en.wikipedia.org/wiki/JSON_Web_Token#Use
https://jwt.io/introduction/ (chapter How do JSON Web Tokens work?)

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>