### PR TITLE
Add another contributor `.mailmap`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,2 @@
 Alberto Simões <ambs@cpan.org> ambs <ambs@cpan.org> <hashashin@gmail.com>
-
+Mikko Koivunalho <mikkoi@cpan.org> Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>


### PR DESCRIPTION
Using `.mailmap` to make names canonical.
These are used by Dist::Zilla::Plugin::Git::Contributors.
"Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>" is not the email
address author uses in CPAN.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>