### PR TITLE
Remove needless assign

### DIFF
--- a/lib/Dancer2/Plugin/JWT.pm
+++ b/lib/Dancer2/Plugin/JWT.pm
@@ -224,7 +224,7 @@ on_plugin_import {
                                                accepted_enc => $enc );
                     };
                     if ($@) {
-                        $app->execute_hook('plugin.jwt.jwt_exception' => ($a = $@));
+                        $app->execute_hook('plugin.jwt.jwt_exception' => $@);
                     };
                     $app->request->var('jwt', $decoded);
                     $app->request->var('jwt_status' => 'present');


### PR DESCRIPTION
Assigning the variable to the special var $a is needless. We just pass the error to jwt_exception hook.

Is there any reason why we are using the special var $a?
Variable $a is used elsewhere in the code but it doesn't reach this scope.