### PR TITLE
Only check the cookie when set_cookie_header set

### DIFF
--- a/lib/Dancer2/Plugin/JWT.pm
+++ b/lib/Dancer2/Plugin/JWT.pm
@@ -204,7 +204,7 @@ on_plugin_import {
                     $encoded = $+{token};
                 }
 
-                if ($app->request->cookies->{_jwt}) {
+                if ($set_cookie_header && $app->request->cookies->{_jwt}) {
                     $encoded = $app->request->cookies->{_jwt}->value ;
                 }
                 elsif ($app->request->param('_jwt')) {


### PR DESCRIPTION
Fixes #20

If set_cookie_header was previously set, but then turned off, client browsers may still have an old cookie from previous requests.

This commit stops the cookie being read if set_cookie_header is off.

It may be that this same logic should be applied to set_authorization_header, but I'm not entirely sure.

For the case of the authorization header, the client code is in control of that, and may want to send authorization headers on requests, but not receive them in responses.

For cookies, the browser handles this and I'm not sure if the client code can even see that cookie.